### PR TITLE
removed main attribute in `package.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 public/bower_components/
+.idea

--- a/package.json
+++ b/package.json
@@ -19,10 +19,6 @@
       "url": "https://github.com/jonmiles/bootstrap-treeview/blob/master/LICENSE"
     }
   ],
-  "main": [
-    "dist/bootstrap-treeview.min.js",
-    "dist/bootstrap-treeview.min.css"
-  ],
   "scripts": {
     "install": "bower install",
     "start": "node app",
@@ -31,12 +27,11 @@
   "engines": {
     "node": ">= 0.10.0"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "express": "3.4.x",
     "ejs": "2.2.x",
-    "phantomjs": "1.9.x"
-  },
-  "devDependencies": {
+    "phantomjs": "1.9.x",
     "bower": "1.3.x",
     "grunt": "0.4.x",
     "grunt-contrib-uglify": "0.7.x",


### PR DESCRIPTION
* determined this was necessary as `npm publish` complains about having multiple files in `main` attribute
* moved **express**, **ejs**, and **phantomjs** to devDependencies to clean up our dependency tree in Patternfly