### PR TITLE
Add event onNodeChanged

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -83,6 +83,7 @@
 		onNodeDisabled: undefined,
 		onNodeEnabled: undefined,
 		onNodeExpanded: undefined,
+		onNodeChanged: undefined,
 		onNodeSelected: undefined,
 		onNodeUnchecked: undefined,
 		onNodeUnselected: undefined,
@@ -269,6 +270,7 @@
 		this.$element.off('nodeDisabled');
 		this.$element.off('nodeEnabled');
 		this.$element.off('nodeExpanded');
+		this.$element.off('nodeChanged');
 		this.$element.off('nodeSelected');
 		this.$element.off('nodeUnchecked');
 		this.$element.off('nodeUnselected');
@@ -323,6 +325,10 @@
 
 		if (typeof (this._options.onNodeExpanded) === 'function') {
 			this.$element.on('nodeExpanded', this._options.onNodeExpanded);
+		}
+
+		if (typeof (this._options.onNodeChanged) === 'function') {
+			this.$element.on('nodeChanged', this._options.onNodeChanged);
 		}
 
 		if (typeof (this._options.onNodeSelected) === 'function') {
@@ -633,7 +639,7 @@
 		return this;
 	};
 
-	Tree.prototype._setSelected = function (node, state, options) {
+	Tree.prototype._setSelected = function (node, state, options, fired = false) {
 
 		// We never pass options when rendering, so the only time
 		// we need to validate state is from user interaction
@@ -644,7 +650,7 @@
 			// If multiSelect false, unselect previously selected
 			if (!this._options.multiSelect) {
 				$.each(this._findNodes('true', 'state.selected'), $.proxy(function (index, node) {
-					this._setSelected(node, false, $.extend(options, {unselecting: true}));
+					this._setSelected(node, false, $.extend(options, {unselecting: true}), true);
 				}, this));
 			}
 
@@ -664,6 +670,7 @@
 
 			// Optionally trigger event
 			this._triggerEvent('nodeSelected', node, options);
+			this._triggerEvent('nodeChanged', node, options);
 		}
 		else {
 
@@ -674,6 +681,7 @@
 				// Fire the nodeSelected event if reselection is allowed
 				if (this._options.allowReselect) {
 					this._triggerEvent('nodeSelected', node, options);
+					this._triggerEvent('nodeChanged', node, options);
 				}
 				return this;
 			}
@@ -694,6 +702,9 @@
 
 			// Optionally trigger event
 			this._triggerEvent('nodeUnselected', node, options);
+			if (!fired) {
+				this._triggerEvent('nodeChanged', node, options);
+			}			
 		}
 
 		return this;


### PR DESCRIPTION
Hi, 
This changes allow to add the event "onNodeChanged": 
Nsow, in no-multislect scenario, when we click in other item onNodeSelect and onNodeUnselect are triggered at the same time. 
This is specially annoying if, for exemple, you are doing an ajax request each time user changes a menu item, because produce duplicated requests (one for onNodeSelect and other for onNodeUnselect.

With this new event you can listen only once any time an user changes a menu item.

Greetings