### PR TITLE
Changes tagsClass definition format

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ If you want to do more, here's the full node specification
     expanded: true,
     selected: true
   },
-  tags: ['available'],
+  tags: [
+    'available',
+    {text:'not available', class:'disabled'}
+  ],
   dataAttr: {
     target: '#tree'
   }
@@ -238,10 +241,14 @@ Whether or not a node is selected.
 
 Used in conjunction with global showTags option to add additional information to the right of each node; using [Bootstrap Badges](http://getbootstrap.com/components/#badges)
 
-#### tagsClass
-`Array of Strings`  `Optional`
+A tag can be an object with properties 'text' for tag value and 'class' for class names(s) of this tag
 
-Used in conjunction with tags option to set class of node tags. The class are defined in the same order of tags. You can set null to use the default value. If class array is smaller than tags array the default value is used.
+#### tagsClass
+`Strings`  `Optional`
+
+String, class names(s).  Default: "badge"
+
+Sets the class of node tags
 
 #### dataAttr
 `Array of Objects`  `Optional`

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -972,13 +972,14 @@
 				node.$el
 					.append(this._template.badge.clone()
 						.addClass(
-							typeof node.tagsClass === 'object'
-							&& id in node.tagsClass
-							&& typeof node.tagsClass[id] === 'string' ?
-								node.tagsClass[id] :
-								this._options.tagsClass
+							(typeof tag === 'object' ? tag.class : undefined)
+							|| node.tagsClass
+							|| this._options.tagsClass
 						)
-						.append(tag)
+						.append(
+							(typeof tag === 'object' ? tag.text : undefined)
+							|| tag
+						)
 					);
 			}, this));
 		}

--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -972,7 +972,9 @@
 				node.$el
 					.append(this._template.badge.clone()
 						.addClass(
-							typeof node.tagsClass[id] === 'string' ?
+							typeof node.tagsClass === 'object'
+							&& id in node.tagsClass
+							&& typeof node.tagsClass[id] === 'string' ?
 								node.tagsClass[id] :
 								this._options.tagsClass
 						)


### PR DESCRIPTION
Hello,

Previously in bootstrap-treeview;
I add the possibility to add an option to set the classes of each nodes. (#34)
Then we get an unexpected result in special case (#37) and (#41)
I made a fix for this issue (#39) but @skateman, @himdel was not happy about this mystical link between tags and tagClasses option.

Today I make this new pull request to fix all this with A new format.
tagsClass is always A string.
tags can be an array of string like before but can also be an array of object like this (or mixed strings and objects):
```javascript
{text: 'Danger !', class: 'label label-danger'}
```
 I made a [jsfiddle](https://jsfiddle.net/Zorim/yka0yaq7/) if you want to check the usage. 

PS: #42 was just a miss click