### PR TITLE
fix problem when use lazyload, can not show child node's color correctly

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -926,6 +926,11 @@
 		// Append .classes to the node
 		node.$el.addClass(node.class);
 
+		// Set Node's Color
+		if (node.color) {
+			node.$el.css('color', node.color);
+		}                
+
 		// Set the #id of the node if specified
 		if (node.id) {
 			node.$el.attr('id', node.id);


### PR DESCRIPTION
when use lazyload to load child node, it's text color can't be showed as the property `node.color` set.