### PR TITLE
Fix styling of node background for portrait icons

### DIFF
--- a/src/css/bootstrap-treeview.css
+++ b/src/css/bootstrap-treeview.css
@@ -55,4 +55,6 @@
 .treeview span.icon.node-icon-background {
   padding: 2px 2px 2px 2px;
   width: calc(1em + 4px);
+  height: calc(1em + 4px);
+  line-height: 1em;
 }


### PR DESCRIPTION
**Before:**
![screenshot from 2018-09-26 09-36-22](https://user-images.githubusercontent.com/649130/46064511-df7f6980-c16f-11e8-956c-d70ee3b032cc.png)

**After:**
![screenshot from 2018-09-26 16-02-22](https://user-images.githubusercontent.com/649130/46085126-9813d000-c1a5-11e8-991d-fc6d7cb1c1d2.png)
