### PR TITLE
Fix node color and background color setting for lazyload

### DIFF
--- a/src/js/bootstrap-treeview.js
+++ b/src/js/bootstrap-treeview.js
@@ -1019,8 +1019,12 @@
 	Tree.prototype._addIcon = function (node) {
 		if (this._options.showIcon && !(this._options.showImage && node.image)) {
 			var icon = this._template.icon.node.clone().addClass(node.icon || this._options.nodeIcon);
+			if (node.iconColor) {
+				icon.css('color', node.iconColor);
+			}
 			if (node.iconBackground) {
 				icon.addClass('node-icon-background');
+				icon.css('background', node.iconBackground);
 			}
 
 			node.$el.append(icon);
@@ -1158,16 +1162,6 @@
 					innerStyle += 'background-color:' + node.backColor + ';';
 				}
 				style += '.node-' + this._elementId + '[data-nodeId="' + node.nodeId + '"]{' + innerStyle + '}';
-			}
-
-			if (node.iconColor) {
-				var innerStyle = 'color:' + node.iconColor + ';';
-				style += '.node-' + this._elementId + '[data-nodeId="' + node.nodeId + '"] .node-icon{' + innerStyle + '}';
-			}
-
-			if (node.iconBackground) {
-				var innerStyle = 'background:' + node.iconBackground + ';';
-				style += '.node-' + this._elementId + '[data-nodeId="' + node.nodeId + '"] .node-icon{' + innerStyle + '}';
 			}
 		}, this));
 


### PR DESCRIPTION
The CSS generation in `_buildStyle` isn't really `lazyLoad` friendly. If the data of a node is loaded after the styling is set, the (node and background) color will not be missing. 

By setting the styling during render time this can be fixed easily.