### PR TITLE
Require bootstrap 3.4.0 to resolve XSS vulnerability

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "jquery": ">= 1.9.0",
-    "bootstrap": ">= 3.0.0"
+    "bootstrap": ">= 3.4.0"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "bootstrap": "3.3.x",
+    "bootstrap": "3.4.x",
     "jquery": ">= 2.1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
patternfly 3.59.0 already requires bootstrap 3.4.0 but this package
pulls in 3.3.7 as a dependency causing 2 different versions in
node_modules/