### PR TITLE
build(deps): bump deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,8 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": ">= 1.9.0",
-    "bootstrap": ">= 3.4.0"
+    "bootstrap": ">= 3.4.1",
+    "jquery": ">= 3.4.1"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "bootstrap": "3.4.x",
-    "jquery": ">= 2.1.x"
+    "bootstrap": "^3.4.1",
+    "jquery": "^3.4.1"
   },
   "devDependencies": {
-    "bower": "1.3.x",
-    "express": "3.4.x",
+    "bower": "^1.8.8",
+    "express": "^4.17.1",
     "grunt": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-cssmin": "^1.0.1",


### PR DESCRIPTION
This is a part of PatternFly 3 Core (https://github.com/patternfly/patternfly) so I'd like for the bootstrap and jQuery versions to align to what I'm bumping them to there.

Towards https://github.com/patternfly/patternfly-org/issues/1431